### PR TITLE
apply_and_finalize will not timeout

### DIFF
--- a/lib/firmware.ex
+++ b/lib/firmware.ex
@@ -116,7 +116,7 @@ defmodule Nerves.Firmware do
   """
   @spec upgrade_and_finalize(String.t) :: :ok | {:error, reason}
   def upgrade_and_finalize(firmware) do
-    GenServer.call @server, {:upgrade_and_finalize, firmware}
+    GenServer.call @server, {:upgrade_and_finalize, firmware}, :infinity
   end
 
   @doc """

--- a/lib/firmware.ex
+++ b/lib/firmware.ex
@@ -129,6 +129,16 @@ defmodule Nerves.Firmware do
   def reboot(), do: logged_shutdown "reboot"
 
   @doc """
+  Reboot the device gracefully
+
+  Issues :init.stop command to gracefully shutdown all applications in the Erlang VM.
+  All code is unloaded and ports closed before the system terminates by calling halt(Status).
+  erlinit.config must be set to reboot on exit(default) for a graceful reboot to work.
+  """
+  @spec reboot(atom) :: :ok
+  def reboot(:graceful), do: :init.stop
+
+  @doc """
   Forces device to power off (without reboot).
   """
   @spec poweroff() :: :ok


### PR DESCRIPTION
I went with :infinity for the timeout, making the assumption that the process would crash in other ways if something goes south with writing the firmware to disk.
