### PR TITLE
Prevent args from being interpreted as HTML tags

### DIFF
--- a/lib/firmware/fwup.ex
+++ b/lib/firmware/fwup.ex
@@ -6,10 +6,11 @@ defmodule Nerves.Firmware.Fwup do
   A Port interface to stream firmware to fwup
 
   Example usage
-    file = File.read!(/path/to/my.fw)
-    {:ok, pid} = Nerves.Firmware.Fwup.start_link([device: "/tmp/test.img", task: "complete"])
-    Nerves.Firmware.Fwup.stream_chunk(pid, file, await: true)
-    Nerves.Firmware.Fwup.stop
+
+      file = File.read!(/path/to/my.fw)
+      {:ok, pid} = Nerves.Firmware.Fwup.start_link([device: "/tmp/test.img", task: "complete"])
+      Nerves.Firmware.Fwup.stream_chunk(pid, file, await: true)
+      Nerves.Firmware.Fwup.stop
 
   """
 

--- a/lib/firmware/fwup.ex
+++ b/lib/firmware/fwup.ex
@@ -90,7 +90,7 @@ defmodule Nerves.Firmware.Fwup do
   end
 
   @doc """
-  Apply the firmware in <input> to the given <device>, executing <task>.
+  Apply the firmware in `input` to the given `device`, executing `task`.
 
   `args` is a list of arguments to be passed to fwup.
 


### PR DESCRIPTION
Fixes onlien docs:
![image](https://user-images.githubusercontent.com/60145/29822651-2ef942ee-8c9a-11e7-95c8-42eb2624adcd.png)

